### PR TITLE
Make it compatible with Webpack 3.0 and update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ If you are looking for the loader which uses [EJS templating engine](https://git
 
 ## Installation
 
-`npm install ejs-loader`
+`npm install ejs-loader --save-dev`
 
 ## Usage
 
@@ -20,19 +20,41 @@ var template = require("./file.ejs");
 template(data) // Pass object with data
 ```
 
+You also should provide a global `_` variable with the lodash/underscore runtime. You can do it with the following webpack plugin: https://webpack.js.org/plugins/provide-plugin/
+
+```
+plugins: [
+    new webpack.ProvidePlugin({
+        _: "lodash"
+    })
+]
+```
+
 ### Options
-[Underscore](http://underscorejs.org/#template)/[Lodash](https://lodash.com/docs#template) options can be passed in using the querystring or adding an ```esjLoader``` options block to your configuration.
+[Underscore](http://underscorejs.org/#template)/[Lodash](https://lodash.com/docs#template) options can be passed in using the querystring or adding or a JSON object to your configuration.
 
 Config example using a querystring:
 ``` js
 module.exports = {
   module: {
     rules: [
-      { test: /\.ejs$/, use: [{loader: 'ejs-loader', options: { variable: 'data'}] },
+      { test: /\.ejs$/, use: [{loader: 'ejs-loader?variable=data'}] },
     ]
   }
 };
 ```
+
+Config example using a JSON object:
+``` js
+module.exports = {
+  module: {
+    rules: [
+      { test: /\.ejs$/, use: [{loader: 'ejs-loader', options: { variable: 'data' }}] },
+    ]
+  }
+};
+```
+
 is equivalent to
 ``` js
 var template = _.template('<%= template %>', { variable : 'data' });
@@ -48,8 +70,8 @@ module.exports = {
                     loader: 'ejs-loader',
                     options: {
                         variable: 'data',
-                        interpolate : '\\{\\{(.+?)\\}\\}', 
-                        evaluate : '\\[\\[(.+?)\\]\\]' 
+                        interpolate : '\\{\\{(.+?)\\}\\}',
+                        evaluate : '\\[\\[(.+?)\\]\\]'
                     }
                 ]
             }
@@ -57,6 +79,7 @@ module.exports = {
     }
 };
 ```
+
 is equivalent to
 ``` js
 var template = _.template('<%= template %>', { variable: 'data', interpolate : '\\{\\{(.+?)\\}\\}', evaluate : '\\[\\[(.+?)\\]\\]' });
@@ -85,7 +108,7 @@ As a result, `renderedHtml` becomes a string `<h1><a href="http://example.com">E
 
 
 ## Release History
-* 0.3.1 - Make it compatible with Webpack 3.0 and update dependencies
+* 1.0.0 - Make it compatible with Webpack 3.0 and update dependencies
 * 0.3.0 - Allow passing template options via `ejsLoader` or via loader's `query`
 * 0.2.1 - Add ability to pass compiller options
 * 0.1.0 - Initial release

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you are looking for the loader which uses [EJS templating engine](https://git
 
 ## Usage
 
-[Documentation: Using loaders](http://webpack.github.io/docs/using-loaders.html)
+[Documentation: Using loaders](https://webpack.js.org/concepts/loaders/)
 
 ``` javascript
 var template = require("./file.ejs");

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you are looking for the loader which uses [EJS templating engine](https://git
 [Documentation: Using loaders](http://webpack.github.io/docs/using-loaders.html)
 
 ``` javascript
-var template = require("ejs!./file.ejs");
+var template = require("./file.ejs");
 // => returns the template function compiled with undesrcore (lodash) templating engine.
 
 // And then use it somewhere in your code
@@ -85,7 +85,7 @@ As a result, `renderedHtml` becomes a string `<h1><a href="http://example.com">E
 
 
 ## Release History
-* 0.3.1 - Make it Webpack 3.0 compatible and update dependencies
+* 0.3.1 - Make it compatible with Webpack 3.0 and update dependencies
 * 0.3.0 - Allow passing template options via `ejsLoader` or via loader's `query`
 * 0.2.1 - Add ability to pass compiller options
 * 0.1.0 - Initial release

--- a/README.md
+++ b/README.md
@@ -20,16 +20,6 @@ var template = require("ejs!./file.ejs");
 template(data) // Pass object with data
 ```
 
-You also should provide a global `_` variable with the lodash/underscore runtime. You can do it with the following webpack plugin: https://github.com/webpack/docs/wiki/list-of-plugins#provideplugin
-
-```
-plugins: [
-    new webpack.ProvidePlugin({
-        _: "underscore"
-    })
-]
-```
-
 ### Options
 [Underscore](http://underscorejs.org/#template)/[Lodash](https://lodash.com/docs#template) options can be passed in using the querystring or adding an ```esjLoader``` options block to your configuration.
 
@@ -37,8 +27,8 @@ Config example using a querystring:
 ``` js
 module.exports = {
   module: {
-    loaders: [
-      { test: /\.ejs$/, loader: 'ejs-loader?variable=data' },
+    rules: [
+      { test: /\.ejs$/, use: [{loader: 'ejs-loader', options: { variable: 'data'}] },
     ]
   }
 };
@@ -51,16 +41,18 @@ var template = _.template('<%= template %>', { variable : 'data' });
 ``` js
 module.exports = {
     module: {
-        loaders: [
+        rules: [
             {
-                test: /\.ejs$/, 
-                loader: 'ejs-loader', 
-                query: { 
-                    variable: 'data', 
-                    interpolate : '\\{\\{(.+?)\\}\\}', 
-                    evaluate : '\\[\\[(.+?)\\]\\]' 
-                }
-            },
+                test: /\.ejs$/,
+                use: [{
+                    loader: 'ejs-loader',
+                    options: {
+                        variable: 'data',
+                        interpolate : '\\{\\{(.+?)\\}\\}', 
+                        evaluate : '\\[\\[(.+?)\\]\\]' 
+                    }
+                ]
+            }
         ]
     }
 };
@@ -69,23 +61,6 @@ is equivalent to
 ``` js
 var template = _.template('<%= template %>', { variable: 'data', interpolate : '\\{\\{(.+?)\\}\\}', evaluate : '\\[\\[(.+?)\\]\\]' });
 ```
-
-Config example using the ```ejsLoader``` config block:
-``` js
-module.exports = {
-  module: {
-    loaders: [
-      { test: /\.ejs$/, loader: 'ejs-loader' }
-    ]
-  },
-  ejsLoader : {
-    variable    : 'data',
-    interpolate : /\{\{(.+?)\}\}/g,
-    evaluate    : /\[\[(.+?)\]\]/g
-  }
-};
-```
-
 
 ### Including nested templates
 
@@ -110,6 +85,7 @@ As a result, `renderedHtml` becomes a string `<h1><a href="http://example.com">E
 
 
 ## Release History
+* 0.3.1 - Make it Webpack 3.0 compatible and update dependencies
 * 0.3.0 - Allow passing template options via `ejsLoader` or via loader's `query`
 * 0.2.1 - Add ability to pass compiller options
 * 0.1.0 - Initial release

--- a/index.js
+++ b/index.js
@@ -3,16 +3,15 @@ var loaderUtils = require('loader-utils');
 
 module.exports = function(source) {
   this.cacheable && this.cacheable();
-  var query = loaderUtils.parseQuery(this.query);
-  var options = this.options.ejsLoader || {};
+  var options = loaderUtils.getOptions(this) || {};
 
   ['escape', 'interpolate', 'evaluate'].forEach(function(templateSetting) {
-    var setting = query[templateSetting];
+    var setting = options[templateSetting];
     if (_.isString(setting)) {
-      query[templateSetting] = new RegExp(setting, 'g');
+      options[templateSetting] = new RegExp(setting, 'g');
     }
   });
 
-  var template = _.template(source, _.extend({}, query, options));
+  var template = _.template(source, _.extend({}, options));
   return 'module.exports = ' + template;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ejs-loader",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "EJS (Underscore/LoDash Templates) loader for webpack",
   "main": "index.js",
   "repository": {
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/okonet/ejs-loader",
   "dependencies": {
-    "lodash": "^3.6.0",
-    "loader-utils": "^0.2.7"
+    "loader-utils": "^1.1.0",
+    "lodash": "^4.17.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ejs-loader",
-  "version": "0.3.1",
+  "version": "0.3.0",
   "description": "EJS (Underscore/LoDash Templates) loader for webpack",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
When used with the latest Webpack it shows:

> DeprecationWarning: loaderUtils.parseQuery() received a non-string value which can be problematic, see https://github.com/webpack/loader-utils/issues/56 parseQuery() will be replaced with getOptions() in the next major version of loader-utils.

I've updated dependencies, documentation and made some changes to make it work properly.