### PR TITLE
Upgrade to lodash 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1493,9 +1493,9 @@
       }
     },
     "lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "loose-envify": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/okonet/ejs-loader",
   "dependencies": {
-    "lodash": "^3.6.0",
+    "lodash": "^4.17.10",
     "loader-utils": "^0.2.7"
   },
   "scripts": {


### PR DESCRIPTION
There's a recent [lodash security advisory](https://hackerone.com/reports/310443) that affects all versions of lodash before 4.17.5. As far as I know, there is no patch for lodash 3.x. While the security issue doesn't affect anything that this package specifically does, it's generally safer to not have vulnerable packages around if possible.