### PR TITLE
update loaderUtils to use 2.0.0 to parse query. deprecate query optio…

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,26 @@ plugins: [
 ### Options
 [Underscore](http://underscorejs.org/#template)/[Lodash](https://lodash.com/docs#template) options can be passed in using the querystring or adding an ```esjLoader``` options block to your configuration.
 
-Config example using a querystring:
+Config example with Webpack 4+
+``` js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.ejs$/,
+        loader: 'ejs-loader',
+        options: {
+          variable: 'data',
+          interpolate : '\\{\\{(.+?)\\}\\}',
+          evaluate : '\\[\\[(.+?)\\]\\]'
+        }
+      }
+    ]
+  }
+};
+```
+
+Config example using a querystring ([deprecated](https://webpack.js.org/concepts/loaders/#loader-features)):
 ``` js
 module.exports = {
   module: {
@@ -73,7 +92,7 @@ is equivalent to
 var template = _.template('<%= template %>', { variable: 'data', interpolate : '\\{\\{(.+?)\\}\\}', evaluate : '\\[\\[(.+?)\\]\\]' });
 ```
 
-Config example using the ```ejsLoader``` config block:
+Config example using the ```ejsLoader``` config block ([deprecated](https://webpack.js.org/concepts/loaders/#loader-features)):
 ``` js
 module.exports = {
   module: {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var loaderUtils = require('loader-utils');
 
 module.exports = function(source) {
   this.cacheable && this.cacheable();
-  var options = loaderUtils.getOptions(this);
+  var options = loaderUtils.getOptions(this) || {};
 
   ['escape', 'interpolate', 'evaluate'].forEach(function(templateSetting) {
     var setting = options[templateSetting];

--- a/index.js
+++ b/index.js
@@ -1,25 +1,17 @@
 var _ = require('lodash');
 var loaderUtils = require('loader-utils');
 
-function getOptions(context) {
-  if (context.options && context.options.ejsLoader) {
-    return context.options.ejsLoader;
-  }
-  return {};
-}
-
 module.exports = function(source) {
   this.cacheable && this.cacheable();
-  var query = loaderUtils.parseQuery(this.query);
-  var options = getOptions(this);
+  var options = loaderUtils.getOptions(this);
 
   ['escape', 'interpolate', 'evaluate'].forEach(function(templateSetting) {
-    var setting = query[templateSetting];
+    var setting = options[templateSetting];
     if (_.isString(setting)) {
-      query[templateSetting] = new RegExp(setting, 'g');
+      options[templateSetting] = new RegExp(setting, 'g');
     }
   });
 
-  var template = _.template(source, _.extend({}, query, options));
+  var template = _.template(source, _.extend({}, options));
   return 'module.exports = ' + template;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -932,9 +932,9 @@
       }
     },
     "big.js": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -1357,9 +1357,9 @@
       "dev": true
     },
     "emojis-list": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -2687,9 +2687,12 @@
       "dev": true
     },
     "json5": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+      "requires": {
+        "minimist": "^1.2.5"
+      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -2732,14 +2735,13 @@
       }
     },
     "loader-utils": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-      "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+      "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
       "requires": {
-        "big.js": "^3.1.3",
-        "emojis-list": "^2.0.0",
-        "json5": "^0.5.0",
-        "object-assign": "^4.0.1"
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
       }
     },
     "locate-path": {
@@ -2853,8 +2855,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -2978,11 +2979,6 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/difelice/ejs-loader",
   "dependencies": {
-    "loader-utils": "^0.2.7",
+    "loader-utils": "^2.0.0",
     "lodash": "^4.17.15"
   },
   "scripts": {


### PR DESCRIPTION
Upgrading [loader-utils](https://www.npmjs.com/package/loader-utils) to version 2.0.0 to give webpack 4 a little love and reduce the amount of options parsing in the loader. Since query options and loader config options are deprecated, I have marked them as such in the readme.