### PR TITLE
add empty object to default to prevent null pointer

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var loaderUtils = require('loader-utils');
 
 module.exports = function (source) {
   this.cacheable && this.cacheable();
-  var options = loaderUtils.getOptions(this);
+  var options = loaderUtils.getOptions(this) || {};
 
   if (options.exportAsESM && !options.variable) {
     throw new Error(`


### PR DESCRIPTION
Due to the new updates with `loaderUtils`, we should really set a default for `this.getOptions`. According to the [`loaderUtils`](https://www.npmjs.com/package/loader-utils) documentation:

```
If this.query is a string:
    Tries to parse the query string and returns a new object
    Throws if it's not a valid query string
If this.query is object-like, it just returns this.query
In any other case, it just returns null
```

Just to guard against the `null` case, I have added a default option.

I apologize as I meant to get this in with #41 ad didn;t update it with #42 :sweat_smile: 