### PR TITLE
Feature/es module rename and default

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ As a result, `renderedHtml` becomes a string `<h1><a href="http://example.com">E
 
 
 ## Release History
+* 0.5.0 - Changed `exportAsESM` flag to `esModule` and enabled this behavior by default to be consistent with other webpack loaders.
 * 0.4.1 - Add default object for options to prevent breakages when the webpack query object is null 
 * 0.4.0 - Add support for ESModules with the `exportAsESM` flag
 * 0.3.5 - Fix dependency vulnerabilities.

--- a/README.md
+++ b/README.md
@@ -108,9 +108,10 @@ module.exports = {
 };
 ```
 
-#### Export as ES Module
-ECMAScript Module mode can be utilized to leverage Webpack 4's code splitting/lazy loading and to gain the benefits of tree shaking. This can be used by setting
-`esModule` to `true` in the loader options.
+#### Export as CommonJS
+By default, `ejs-loader` generates JS modules that use the ES modules syntax. There are some cases in which using ES modules is beneficial, like in the case of [module concatenation](https://webpack.js.org/plugins/module-concatenation-plugin/) and [tree shaking](https://webpack.js.org/guides/tree-shaking/).
+
+You can enable a CommonJS module syntax using:
 
 Config example with Webpack 4+
 ``` js
@@ -121,8 +122,7 @@ module.exports = {
         test: /\.ejs$/,
         loader: 'ejs-loader',
         options: {
-          variable: 'data',
-          esModule: true
+          esModule: false
         }
       }
     ]

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ As a result, `renderedHtml` becomes a string `<h1><a href="http://example.com">E
 
 
 ## Release History
+* 0.4.1 - Add default object for options to prevent breakages when the webpack query object is null 
+* 0.4.0 - Add support for ESModules with the `exportAsESM` flag
 * 0.3.5 - Fix dependency vulnerabilities.
 * 0.3.3 - Fix dependency vulnerabilities.
 * 0.3.0 - Allow passing template options via `ejsLoader` or via loader's `query`

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ module.exports = {
 
 #### Export as ES Module
 ECMAScript Module mode can be utilized to leverage Webpack 4's code splitting/lazy loading and to gain the benefits of tree shaking. This can be used by setting
-`exportAsESM` to `true` in the loader options.
+`esModule` to `true` in the loader options.
 
 Config example with Webpack 4+
 ``` js
@@ -122,7 +122,7 @@ module.exports = {
         loader: 'ejs-loader',
         options: {
           variable: 'data',
-          exportAsESM: true
+          esModule: true
         }
       }
     ]

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -10,7 +10,7 @@ describe('ejsLoader', () => {
     expect(compiled(params)).toBe('<div>Hello World!</div>');
   });
 
-  describe('ejsLoader with ESModules feature', () => {
+  describe('ejsLoader with "ESModule" feature', () => {
     const compileTemplate = (template, mockedLoaderContext = {}) => {
       const mergedMockedLoaderContext = {
         cacheable: null,
@@ -33,7 +33,7 @@ describe('ejsLoader', () => {
       const compilerOptions = {
         query: {
           variable: 'args',
-          exportAsESM: true
+          esModule: true
         }
       };
       const compiled = convertTemplateStringToFunction(compileTemplate(template, compilerOptions));
@@ -44,7 +44,7 @@ describe('ejsLoader', () => {
       const template = '<div>Hello <%= args.world %>!</div>';
       const compilerOptions = {
         query: {
-          exportAsESM: true
+          esModule: true
         }
       };
       

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -2,24 +2,28 @@ const requireFromString = require('require-from-string');
 const ejsLoader = require('../index.js');
 
 describe('ejsLoader', () => {
-  it('returns template with applied parameters', () => {
+  const compileTemplate = (template, mockedLoaderContext = {}) => {
+    const mergedMockedLoaderContext = {
+      cacheable: null,
+      ...mockedLoaderContext
+    };
+  
+    return ejsLoader.call(mergedMockedLoaderContext, template);
+  }
+
+  it('returns template with applied parameters in CommonJS with "esModule" set to false', () => {
+    const compilerOptions = {
+      query: {
+        esModule: false
+      }
+    };
     const template = '<div>Hello <%= world %>!</div>';
     const params = { world: 'World' };
-    const compiled = requireFromString(ejsLoader(template));
-
+    const compiled = requireFromString(compileTemplate(template, compilerOptions));
     expect(compiled(params)).toBe('<div>Hello World!</div>');
   });
 
-  describe('ejsLoader with "ESModule" feature', () => {
-    const compileTemplate = (template, mockedLoaderContext = {}) => {
-      const mergedMockedLoaderContext = {
-        cacheable: null,
-        ...mockedLoaderContext
-      };
-    
-      return ejsLoader.call(mergedMockedLoaderContext, template);
-    }
-    
+  describe('ejsLoader with "esModule" feature', () => {
     const convertTemplateStringToFunction = (templateString) => {
       const removeExportDefaultString = templateString.match(/export default (.*)/s)[1];
       return new Function(`return ${removeExportDefaultString}`)();
@@ -32,8 +36,7 @@ describe('ejsLoader', () => {
       };
       const compilerOptions = {
         query: {
-          variable: 'args',
-          esModule: true
+          variable: 'args'
         }
       };
       const compiled = convertTemplateStringToFunction(compileTemplate(template, compilerOptions));
@@ -42,14 +45,9 @@ describe('ejsLoader', () => {
 
     it('throws error when options variable or query variable are undefined', () => {
       const template = '<div>Hello <%= args.world %>!</div>';
-      const compilerOptions = {
-        query: {
-          esModule: true
-        }
-      };
       
       expect(() => {
-        compileTemplate(template, compilerOptions)
+        compileTemplate(template)
       }).toThrowError();
     });
   })

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,8 +1,8 @@
 const requireFromString = require('require-from-string');
 const ejsLoader = require('../index.js');
 
-describe('ejsLoader', function() {
-  it('returns template with applied parameters', function() {
+describe('ejsLoader', () => {
+  it('returns template with applied parameters', () => {
     const template = '<div>Hello <%= world %>!</div>';
     const params = { world: 'World' };
     const compiled = requireFromString(ejsLoader(template));

--- a/index.js
+++ b/index.js
@@ -6,12 +6,13 @@ var loaderUtils = require('loader-utils');
 module.exports = function (source) {
   this.cacheable && this.cacheable();
   var options = loaderUtils.getOptions(this) || {};
+  var useESModule = options.esModule !== false;
 
-  if (options.esModule && !options.variable) {
+  if (useESModule && !options.variable) {
     throw new Error(`
       To support the 'esModule' option, the 'variable' option must be passed to avoid 'with' statements
-      in the compiled template to be strict mode compatible.
-      Please see https://github.com/lodash/lodash/issues/3709#issuecomment-375898111
+      in the compiled template to be strict mode compatible. Please see https://github.com/lodash/lodash/issues/3709#issuecomment-375898111.
+      To enable CommonJS, please set the 'esModule' option to false.
     `);
   }
 
@@ -23,7 +24,7 @@ module.exports = function (source) {
   });
 
   var template = lodashTemplate(source, lodashExtend({}, options));
-  return options.esModule
+  return useESModule
     ? `export default ${template}`
     : `module.exports = ${template}`;
 };

--- a/index.js
+++ b/index.js
@@ -7,9 +7,9 @@ module.exports = function (source) {
   this.cacheable && this.cacheable();
   var options = loaderUtils.getOptions(this) || {};
 
-  if (options.exportAsESM && !options.variable) {
+  if (options.esModule && !options.variable) {
     throw new Error(`
-      To support ES Modules, the 'variable' option must be passed to avoid 'with' statements
+      To support the 'esModule' option, the 'variable' option must be passed to avoid 'with' statements
       in the compiled template to be strict mode compatible.
       Please see https://github.com/lodash/lodash/issues/3709#issuecomment-375898111
     `);
@@ -23,7 +23,7 @@ module.exports = function (source) {
   });
 
   var template = lodashTemplate(source, lodashExtend({}, options));
-  return options.exportAsESM
+  return options.esModule
     ? `export default ${template}`
     : `module.exports = ${template}`;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ejs-loader",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ejs-loader",
-  "version": "0.3.7",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ejs-loader",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "EJS (Underscore/LoDash Templates) loader for webpack",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Opened to address issue https://github.com/difelice/ejs-loader/issues/44

In summary, the goal of this PR is to use the option name `esModule` instead of `exportAsESM`. This PR will also enable this behavior by default. This will help this loader be consistent with the following webpack loaders:

Just to be coherent with other loaders such as:
- https://webpack.js.org/loaders/file-loader/#esmodule
- https://webpack.js.org/loaders/raw-loader/#esmodule
- https://webpack.js.org/loaders/url-loader/#esmodule
- https://webpack.js.org/loaders/json5-loader/#esmodule
- https://webpack.js.org/plugins/mini-css-extract-plugin/#esmodule